### PR TITLE
Add index of AP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
-# analytics-platform
-Parent repository for the MOJ Analytics Platform. See [Wiki](https://github.com/ministryofjustice/analytics-platform/wiki) for more information.
+# Analytical Platform
 
-You can see a listing of all the repositories which are part of the platform [here](https://github.com/ministryofjustice?utf8=%E2%9C%93&q=analytics-platform&type=&language=).
+This is the root repository for the MOJ Analytical Platform.
 
-For an introduction to what the platform does, see the [User Guidance](https://user-guidance.services.alpha.mojanalytics.xyz/introduction.html#what-is-the-analytical-platform).
+Repositories: The platform is all open source - see all the repositories here: https://github.com/search?q=topic%3Aanalytics-platform+org%3Aministryofjustice&type=Repositories Within the repos there are some config files containing secrets, which are included in encrypted form.
+
+## Index of documentation
+
+* [User Guidance](https://user-guidance.services.alpha.mojanalytics.xyz/#content)
+* Technical Architecture
+  * [Overview](https://github.com/ministryofjustice/analytics-platform-ops/tree/main/docs/architecture)
+  * [Architecture diagrams](https://github.com/ministryofjustice/analytics-platform-ops/tree/main/docs/architecture#Diagrams)
+  * [Architecture Design Records](https://drive.google.com/drive/u/0/folders/1eloHciWhczk1ITTtyqKv5dZM_6P1Pnlf) (private currently) - Discussion of technical choices
+* Wiki - https://github.com/ministryofjustice/analytics-platform/wiki 
+  * Runbook / operation guides for all the main parts of the system
+* README files in the AP GitHub repos - about the repository. In particular:
+  * [-ops](https://github.com/ministryofjustice/analytics-platform-ops) which documents the initial deployment of the platform
+  * [-iam](https://github.com/ministryofjustice/analytical-platform-iam) which describes the IAM permissions and 'landing' AWS account
+  * [-helm-charts](https://github.com/ministryofjustice/analytics-platform-helm-charts) which contains the helm charts running on Kubernetes 
+* [Technical Notes on MOJ AP infrastructure](https://docs.google.com/document/d/1aOOocs54U9HqmimraSv8pz-MJ8HWfTCFTxnfvFVRkDA/edit#heading=h.1j4ud911cmi5) (private)


### PR DESCRIPTION
I'm keen to have an index for all the bits of docs, and refer back to it from the Tech Arch docs, wiki etc.