### PR TITLE
Point at the new ap-tech-docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 This is the root repository for the MOJ Analytical Platform.
 
-Repositories: The platform is all open source - see all the repositories here: https://github.com/search?q=topic%3Aanalytics-platform+org%3Aministryofjustice&type=Repositories Within the repos there are some config files containing secrets, which are included in encrypted form.
+Repositories: The platform is all open source - see all the repositories here: https://github.com/search?q=topic%3Aanalytics-platform+org%3Aministryofjustice&type=Repositories
+
+Within the repos there are some config files containing secrets, which are included in encrypted form.
 
 ## Index of documentation
 
 * [User Guidance](https://user-guidance.services.alpha.mojanalytics.xyz/#content)
-* Technical Architecture
-  * [Overview](https://github.com/ministryofjustice/analytics-platform-ops/tree/main/docs/architecture)
-  * [Architecture diagrams](https://github.com/ministryofjustice/analytics-platform-ops/tree/main/docs/architecture#Diagrams)
-  * [Architecture Design Records](https://drive.google.com/drive/u/0/folders/1eloHciWhczk1ITTtyqKv5dZM_6P1Pnlf) (private currently) - Discussion of technical choices
+* Technical Architecture (Alpha)
+  * [Overview](https://ministryofjustice.github.io/ap-tech-docs/documentation/30-architecture/40-alpha-architecture/#alpha-architecture)
+  * [Architecture diagrams](https://ministryofjustice.github.io/ap-tech-docs/documentation/30-architecture/40-alpha-architecture/#alpha-architecture)
+  * [Architecture Design Records](https://ministryofjustice.github.io/ap-tech-docs/documentation/30-architecture/40-architecture-decision-records/#architecture-decision-records) (private currently) - Discussion of technical choices
 * Team docs https://ministryofjustice.github.io/ap-tech-docs (private)
   * Runbook / operation guides for all the main parts of the system (includes content migrated from the old wiki)
 * README files in the AP GitHub repos - about the repository. In particular:
   * [-ops](https://github.com/ministryofjustice/analytics-platform-ops) which documents the initial deployment of the platform
   * [-iam](https://github.com/ministryofjustice/analytical-platform-iam) which describes the IAM permissions and 'landing' AWS account
-  * [-helm-charts](https://github.com/ministryofjustice/analytics-platform-helm-charts) which contains the helm charts running on Kubernetes 
+  * [-helm-charts](https://github.com/ministryofjustice/analytics-platform-helm-charts) which contains the helm charts running on Kubernetes
 * [Technical Notes on MOJ AP infrastructure](https://docs.google.com/document/d/1aOOocs54U9HqmimraSv8pz-MJ8HWfTCFTxnfvFVRkDA/edit#heading=h.1j4ud911cmi5) (private)


### PR DESCRIPTION
A lot of documentation has already moved to the ap-tech-docs site, and
so this PR links there instead of to the github repositories.